### PR TITLE
Add files via upload

### DIFF
--- a/proxy.py
+++ b/proxy.py
@@ -1,0 +1,17 @@
+import os
+import sys
+import time
+
+os.system('iptables -F;')
+os.system('echo "FLUSHING IPTABLES!"')
+os.system('iptables -t nat -F;')
+os.system('echo "FLUSHING NAT"')
+os.system('echo "1" > /proc/sys/net/ipv4/ip_forward;')
+os.system('iptables -A FORWARD -i eth0 -j ACCEPT;')
+os.system('iptables -A FORWARD -o eth0 -j ACCEPT;')
+os.system('iptables -I FORWARD -i eth0 -p tcp --dport 1337 -j ACCEPT;')
+os.system('echo "SETTING FAKE CNC PORT"')
+os.system('iptables -t nat -A PREROUTING -p tcp --dport 1337 -j DNAT --to 1.1.1.1:80;')
+os.system('echo "JUST LINKED THE CNC!"')
+os.system('iptables -t nat -A POSTROUTING -j MASQUERADE;')
+os.system('echo "Finished Setting PROXY!"')


### PR DESCRIPTION
Reverse Proxy Python Iptables Script.
Example on how to run script:
python proxy.py
python3 proxy.py
a Reverse Proxy Python script.
why in python? well, you can set timeout, and sleep. and make it loop, over & over,  that being said, you can set a timeout 1200 command, and every 20 minutes it will proxy again. actually very useful i think. any questions. let me know. thank you.